### PR TITLE
Add DominatorAgent service and installer

### DIFF
--- a/DominatorAgent/DominatorAgent.cs
+++ b/DominatorAgent/DominatorAgent.cs
@@ -1,0 +1,82 @@
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Management;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Hosting;
+
+public class DominatorAgent : BackgroundService
+{
+    private readonly HttpClient _httpClient = new HttpClient();
+    private readonly string _logPath = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "agent.log");
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            try
+            {
+                var data = new
+                {
+                    machineName = Environment.MachineName,
+                    user = Environment.UserName,
+                    uptime = TimeSpan.FromMilliseconds(Environment.TickCount64).ToString(),
+                    updates = GetInstalledUpdates()
+                };
+                var json = JsonSerializer.Serialize(data);
+                var content = new StringContent(json, Encoding.UTF8, "application/json");
+                var response = await _httpClient.PostAsync("https://example.com/checkin", content, stoppingToken);
+                response.EnsureSuccessStatusCode();
+                Log($"Sent check-in at {DateTime.UtcNow}. Status: {response.StatusCode}");
+            }
+            catch (Exception ex)
+            {
+                Log($"Error during check-in: {ex.Message}");
+            }
+
+            try
+            {
+                await Task.Delay(TimeSpan.FromSeconds(60), stoppingToken);
+            }
+            catch (TaskCanceledException)
+            {
+            }
+        }
+    }
+
+    private List<object> GetInstalledUpdates()
+    {
+        var updates = new List<object>();
+        try
+        {
+            using var searcher = new ManagementObjectSearcher("SELECT HotFixID, Description FROM Win32_QuickFixEngineering");
+            foreach (ManagementObject update in searcher.Get())
+            {
+                var hotFix = update["HotFixID"]?.ToString();
+                var desc = update["Description"]?.ToString();
+                updates.Add(new { name = desc, kb = hotFix });
+            }
+        }
+        catch (Exception ex)
+        {
+            Log($"Error retrieving updates: {ex.Message}");
+        }
+        return updates;
+    }
+
+    private void Log(string message)
+    {
+        try
+        {
+            File.AppendAllText(_logPath, $"[{DateTime.Now}] {message}{Environment.NewLine}");
+        }
+        catch
+        {
+        }
+    }
+}

--- a/DominatorAgent/DominatorAgent.csproj
+++ b/DominatorAgent/DominatorAgent.csproj
@@ -1,0 +1,9 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net9.0</TargetFramework>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.Extensions.Hosting.WindowsServices" Version="9.0.0" />
+  </ItemGroup>
+</Project>

--- a/DominatorAgent/Program.cs
+++ b/DominatorAgent/Program.cs
@@ -1,0 +1,12 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .UseWindowsService()
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<DominatorAgent>();
+    })
+    .Build();
+
+host.Run();

--- a/DominatorAgent/installer.nsi
+++ b/DominatorAgent/installer.nsi
@@ -1,0 +1,22 @@
+!include "MUI2.nsh"
+
+Name "DominatorAgent"
+OutFile "DominatorAgentInstaller.exe"
+InstallDir "$PROGRAMFILES\DominatorAgent"
+
+Page Directory
+Page InstFiles
+
+Section "Install"
+    SetOutPath "$INSTDIR"
+    File /r "publish\*.*"
+    nsExec::Exec '"$SYSDIR\sc.exe" create DominatorAgent binPath= "\"$INSTDIR\DominatorAgent.exe\"" start= auto'
+    nsExec::Exec '"$SYSDIR\sc.exe" start DominatorAgent'
+SectionEnd
+
+Section "Uninstall"
+    nsExec::Exec '"$SYSDIR\sc.exe" stop DominatorAgent'
+    nsExec::Exec '"$SYSDIR\sc.exe" delete DominatorAgent'
+    Delete "$INSTDIR\*.*"
+    RMDir "$INSTDIR"
+SectionEnd

--- a/README.md
+++ b/README.md
@@ -1,1 +1,15 @@
-# Dominator
+# DominatorAgent
+
+DominatorAgent is a lightweight Windows background service built with .NET 9. It periodically reports basic system information to `https://example.com/checkin`.
+
+## Building
+
+1. Install the .NET 9 SDK.
+2. Navigate to the `DominatorAgent` folder.
+3. Run `dotnet publish -c Release -o publish`.
+
+## Installation
+
+An example `installer.nsi` script is provided for NSIS. After publishing the project, compile the installer script to create `DominatorAgentInstaller.exe`.
+
+The installer copies the service files to `Program Files` and registers the service to start automatically on boot.


### PR DESCRIPTION
## Summary
- add DominatorAgent Windows service
- implement background worker with HTTP check‑ins and local logging
- include NSIS installer script and basic build instructions

## Testing
- `dotnet publish -c Release -o publish` *(fails: dotnet not installed)*

------
https://chatgpt.com/codex/tasks/task_e_685cb1a3f9c4832196815f19dda76cb6