### PR TITLE
Add DominatorRelay Flask API

### DIFF
--- a/DominatorRelay/README.md
+++ b/DominatorRelay/README.md
@@ -1,0 +1,38 @@
+# DominatorRelay
+
+DominatorRelay is a small Flask API that collects check-in data from Dominator agents.
+
+## Endpoints
+
+- `POST /checkin` – send a JSON payload containing at least a `device_id` field. The request
+  must include the header `Authorization: Bearer <token>`.
+- `GET /devices` – returns all saved check-in payloads as JSON. Requires the same token header.
+
+Set the environment variable `API_TOKEN` to define the expected token. If not set,
+`changeme` is used.
+
+## Running Locally
+
+```bash
+# create virtual environment and install dependencies
+./install.sh
+
+# set the API token
+export API_TOKEN=mysecrettoken
+
+# start the development server
+source venv/bin/activate
+python app.py
+```
+
+The server listens on `http://0.0.0.0:5000`.
+
+## Running with Gunicorn
+
+```bash
+source venv/bin/activate
+export API_TOKEN=mysecrettoken
+
+# start gunicorn with 4 workers
+gunicorn -w 4 -b 0.0.0.0:8000 app:app
+```

--- a/DominatorRelay/app.py
+++ b/DominatorRelay/app.py
@@ -1,0 +1,39 @@
+from flask import Flask, request, jsonify, abort
+import os
+
+app = Flask(__name__)
+
+checkins = {}
+API_TOKEN = os.environ.get("API_TOKEN", "changeme")
+
+
+def require_token():
+    auth = request.headers.get("Authorization")
+    if not auth or not auth.startswith("Bearer "):
+        abort(401)
+    token = auth.split(" ", 1)[1]
+    if token != API_TOKEN:
+        abort(403)
+
+
+@app.route("/checkin", methods=["POST"])
+def checkin():
+    require_token()
+    if not request.is_json:
+        return jsonify({"error": "Invalid JSON"}), 400
+    data = request.get_json()
+    device_id = data.get("device_id")
+    if not device_id:
+        return jsonify({"error": "device_id required"}), 400
+    checkins[device_id] = data
+    return jsonify({"status": "ok"})
+
+
+@app.route("/devices", methods=["GET"])
+def devices():
+    require_token()
+    return jsonify(checkins)
+
+
+if __name__ == "__main__":
+    app.run(host="0.0.0.0", port=5000)

--- a/DominatorRelay/install.sh
+++ b/DominatorRelay/install.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -e
+python3 -m venv venv
+source venv/bin/activate
+pip install --upgrade pip
+pip install -r requirements.txt

--- a/DominatorRelay/requirements.txt
+++ b/DominatorRelay/requirements.txt
@@ -1,0 +1,2 @@
+Flask>=2.2
+Gunicorn>=21.2

--- a/README.md
+++ b/README.md
@@ -13,3 +13,10 @@ DominatorAgent is a lightweight Windows background service built with .NET 9. It
 An example `installer.nsi` script is provided for NSIS. After publishing the project, compile the installer script to create `DominatorAgentInstaller.exe`.
 
 The installer copies the service files to `Program Files` and registers the service to start automatically on boot.
+
+---
+
+## DominatorRelay
+
+DominatorRelay is a small Python Flask API that receives check-ins from Dominator agents.
+See the [DominatorRelay](./DominatorRelay/README.md) directory for details on running it.


### PR DESCRIPTION
## Summary
- add DominatorRelay subproject with Flask API
- document endpoints and usage
- update root README to reference DominatorRelay

## Testing
- `python3 -m py_compile DominatorRelay/app.py`

------
https://chatgpt.com/codex/tasks/task_e_685cb29c1240832196f9f7a6fed4499f